### PR TITLE
[FEAT]: codef 연동 connected_id 발급 및 access_token 갱신

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,9 @@ dependencies {
     implementation 'com.mysql:mysql-connector-j:8.1.0'
     implementation 'com.zaxxer:HikariCP:2.7.4'
 
+    // 로컬 캐시 (caffeine)
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
+
     implementation "org.springframework:spring-tx:${springVersion}"
     implementation "org.springframework:spring-jdbc:${springVersion}"
 
@@ -80,6 +83,12 @@ dependencies {
     implementation 'org.springframework.security:spring-security-core:5.8.6'
     implementation 'org.springframework.security:spring-security-web:5.8.6'
     implementation 'org.springframework.security:spring-security-crypto:5.8.6'
+
+    //Http components
+    implementation 'org.apache.httpcomponents:httpclient:4.5.13'
+
+    //jackson
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.3'
 
     //Fly way
     implementation "org.flywaydb:flyway-core:${flywayVersion}"

--- a/src/main/java/woojooin/planit/global/config/CacheConfig.java
+++ b/src/main/java/woojooin/planit/global/config/CacheConfig.java
@@ -1,0 +1,31 @@
+package woojooin.planit.global.config;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import woojooin.planit.global.util.codef.dto.res.CodefTokenRes;
+
+@Configuration
+public class CacheConfig {
+
+	@Bean
+	public Cache<String, Object> localCache() {
+		return Caffeine.newBuilder()
+			.maximumSize(10_000)
+			.expireAfterWrite(10, TimeUnit.MINUTES)
+			.build();
+	}
+
+	@Bean
+	public Cache<String, CodefTokenRes> localCodefCache() {
+		return Caffeine.newBuilder()
+			.maximumSize(10_000)
+			.expireAfterWrite(10, TimeUnit.MINUTES)
+			.build();
+	}
+}

--- a/src/main/java/woojooin/planit/global/config/FlywayConfig.java
+++ b/src/main/java/woojooin/planit/global/config/FlywayConfig.java
@@ -15,11 +15,7 @@ public class FlywayConfig {
 			.locations("classpath:db/migration")
 			.baselineOnMigrate(true)
 			.load();
-
-		// ❗ repair 먼저 실행하고
 		flyway.repair();
-
-		// ✅ 그 다음 migrate 정상 실행
 		return flyway;
 	}
 }

--- a/src/main/java/woojooin/planit/global/config/RestTemplateConfig.java
+++ b/src/main/java/woojooin/planit/global/config/RestTemplateConfig.java
@@ -1,0 +1,53 @@
+package woojooin.planit.global.config;
+
+import java.util.List;
+
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+
+/**
+ * RestTemplate snake 자동 변환을 위한 설정
+ *  - Connection pool 생성
+ */
+@Configuration
+public class RestTemplateConfig {
+
+	@Bean
+	public RestTemplate restTemplate() {
+		// 1. 커넥션 풀 설정
+		PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
+		connectionManager.setMaxTotal(200);              // 전체 커넥션 최대값
+		connectionManager.setDefaultMaxPerRoute(50);     // 도메인 당 최대 커넥션 수
+
+		CloseableHttpClient httpClient = HttpClients.custom()
+			.setConnectionManager(connectionManager)
+			.build();
+
+		HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory(httpClient);
+
+		// 2. ObjectMapper에 snake_case 설정
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+
+		MappingJackson2HttpMessageConverter jacksonConverter = new MappingJackson2HttpMessageConverter();
+		jacksonConverter.setObjectMapper(objectMapper);
+
+		// 3. RestTemplate 생성 및 커스텀 컨버터 등록
+		RestTemplate restTemplate = new RestTemplate(factory);
+		List<HttpMessageConverter<?>> converters = restTemplate.getMessageConverters();
+		converters.removeIf(c -> c instanceof MappingJackson2HttpMessageConverter); // 기존 제거
+		converters.add(jacksonConverter);
+
+		return restTemplate;
+	}
+}

--- a/src/main/java/woojooin/planit/global/config/RestTemplateConfig.java
+++ b/src/main/java/woojooin/planit/global/config/RestTemplateConfig.java
@@ -14,6 +14,7 @@ import org.springframework.web.client.RestTemplate;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 
 /**
  * RestTemplate snake 자동 변환을 위한 설정
@@ -22,12 +23,24 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 @Configuration
 public class RestTemplateConfig {
 
-	@Bean
-	public RestTemplate restTemplate() {
-		// 1. 커넥션 풀 설정
+	// snake_case RestTemplate
+	@Bean("snakeRestTemplate")
+	public RestTemplate snakeRestTemplate() {
+		return createRestTemplate(PropertyNamingStrategies.SNAKE_CASE);
+	}
+
+	// camelCase RestTemplate
+	@Bean("camelRestTemplate")
+	public RestTemplate camelRestTemplate() {
+		return createRestTemplate(PropertyNamingStrategies.LOWER_CAMEL_CASE);
+	}
+
+	private RestTemplate createRestTemplate(PropertyNamingStrategy namingStrategy) {
+
+		//RestTemplate 커넥션풀 설정
 		PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
-		connectionManager.setMaxTotal(200);              // 전체 커넥션 최대값
-		connectionManager.setDefaultMaxPerRoute(50);     // 도메인 당 최대 커넥션 수
+		connectionManager.setMaxTotal(200);
+		connectionManager.setDefaultMaxPerRoute(50);
 
 		CloseableHttpClient httpClient = HttpClients.custom()
 			.setConnectionManager(connectionManager)
@@ -35,18 +48,16 @@ public class RestTemplateConfig {
 
 		HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory(httpClient);
 
-		// 2. ObjectMapper에 snake_case 설정
 		ObjectMapper objectMapper = new ObjectMapper();
-		objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+		objectMapper.setPropertyNamingStrategy(namingStrategy);
 
-		MappingJackson2HttpMessageConverter jacksonConverter = new MappingJackson2HttpMessageConverter();
-		jacksonConverter.setObjectMapper(objectMapper);
+		MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
+		converter.setObjectMapper(objectMapper);
 
-		// 3. RestTemplate 생성 및 커스텀 컨버터 등록
 		RestTemplate restTemplate = new RestTemplate(factory);
 		List<HttpMessageConverter<?>> converters = restTemplate.getMessageConverters();
-		converters.removeIf(c -> c instanceof MappingJackson2HttpMessageConverter); // 기존 제거
-		converters.add(jacksonConverter);
+		converters.removeIf(c -> c instanceof MappingJackson2HttpMessageConverter);
+		converters.add(converter);
 
 		return restTemplate;
 	}

--- a/src/main/java/woojooin/planit/global/config/ServletConfig.java
+++ b/src/main/java/woojooin/planit/global/config/ServletConfig.java
@@ -10,25 +10,24 @@ import org.springframework.web.servlet.view.JstlView;
 
 @EnableWebMvc
 @ComponentScan(basePackages = {
-        "woojooin.planit.domain.member.controller",
-        "woojooin.planit.global.security.controller"
+	"woojooin.planit"
 })
-public class ServletConfig  implements WebMvcConfigurer {
-    @Override
-    public void addResourceHandlers(ResourceHandlerRegistry registry) {
-        registry
-                .addResourceHandler("/resources/**")
-                .addResourceLocations("/resources/");
-    }
+public class ServletConfig implements WebMvcConfigurer {
+	@Override
+	public void addResourceHandlers(ResourceHandlerRegistry registry) {
+		registry
+			.addResourceHandler("/resources/**")
+			.addResourceLocations("/resources/");
+	}
 
-    @Override
-    public void configureViewResolvers(ViewResolverRegistry registry) {
-        InternalResourceViewResolver bean = new InternalResourceViewResolver();
+	@Override
+	public void configureViewResolvers(ViewResolverRegistry registry) {
+		InternalResourceViewResolver bean = new InternalResourceViewResolver();
 
-        bean.setViewClass(JstlView.class);
-        bean.setPrefix("/WEB-INF/views/");
-        bean.setSuffix(".jsp");
+		bean.setViewClass(JstlView.class);
+		bean.setPrefix("/WEB-INF/views/");
+		bean.setSuffix(".jsp");
 
-        registry.viewResolver(bean);
-    }
+		registry.viewResolver(bean);
+	}
 }

--- a/src/main/java/woojooin/planit/global/security/SecurityConfig.java
+++ b/src/main/java/woojooin/planit/global/security/SecurityConfig.java
@@ -10,45 +10,47 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
 import woojooin.planit.global.security.jwt.JwtAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
-    @Autowired
-    private JwtAuthenticationFilter jwtAuthFilter;
-    @Autowired
-    private CustomUserDetailsService userDetailsService;
-    @Autowired
-    private BCryptPasswordEncoder passwordEncoder;
+	@Autowired
+	private JwtAuthenticationFilter jwtAuthFilter;
+	@Autowired
+	private CustomUserDetailsService userDetailsService;
+	@Autowired
+	private BCryptPasswordEncoder passwordEncoder;
 
-    @Override
-    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
-        auth.userDetailsService(userDetailsService)
-                .passwordEncoder(passwordEncoder);
-    }
+	@Override
+	protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+		auth.userDetailsService(userDetailsService)
+			.passwordEncoder(passwordEncoder);
+	}
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-        http.csrf().disable()
+	@Override
+	protected void configure(HttpSecurity http) throws Exception {
+		http.csrf().disable()
 
-                .authorizeRequests()
-                .antMatchers("/api/login").permitAll()
-                .anyRequest().authenticated()
+			.authorizeRequests()
+			.antMatchers("/test/**").permitAll()
+			.antMatchers("/api/login").permitAll()
+			.anyRequest().authenticated()
 
-                .and()
-                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
-    }
+			.and()
+			.addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+	}
 
-    @Bean
-    @Override
-    public AuthenticationManager authenticationManagerBean() throws Exception {
-        return super.authenticationManagerBean();
-    }
+	@Bean
+	@Override
+	public AuthenticationManager authenticationManagerBean() throws Exception {
+		return super.authenticationManagerBean();
+	}
 
-    @Bean
-    public BCryptPasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
+	@Bean
+	public BCryptPasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
 }

--- a/src/main/java/woojooin/planit/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/woojooin/planit/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,58 +1,69 @@
 package woojooin.planit.global.security.jwt;
 
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
-import woojooin.planit.global.security.CustomUserDetailsService;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import woojooin.planit.global.security.CustomUserDetailsService;
 
 /**
  * JWT 토큰 필터
  */
+@Slf4j
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-    private final String AUTHORIZATION_HEADER = "Authorization";
-    private final String BEARER_PREFIX = "Bearer ";
+	private final String AUTHORIZATION_HEADER = "Authorization";
+	private final String BEARER_PREFIX = "Bearer ";
 
-    @Autowired
-    private JwtTokenProvider jwtTokenProvider;
-    @Autowired private CustomUserDetailsService userDetailsService;
+	@Autowired
+	private JwtTokenProvider jwtTokenProvider;
+	@Autowired
+	private CustomUserDetailsService userDetailsService;
 
-    @Override
-    protected void doFilterInternal(HttpServletRequest request,
-                                    HttpServletResponse response,
-                                    FilterChain filterChain)
-            throws ServletException, IOException {
+	@Override
+	protected void doFilterInternal(HttpServletRequest request,
+		HttpServletResponse response,
+		FilterChain filterChain)
+		throws ServletException, IOException {
 
-        String token = resolveToken(request);
+		if (request.getRequestURI().startsWith("/test")) {
+			log.info("Bypassing JWT filter for URI: {}", request.getRequestURI());
+			filterChain.doFilter(request, response);
+			return;
+		}
 
-        if (token != null && jwtTokenProvider.validateToken(token)) {
-            String username = jwtTokenProvider.getUsername(token);
-            UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+		String token = resolveToken(request);
 
-            UsernamePasswordAuthenticationToken auth =
-                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+		if (token != null && jwtTokenProvider.validateToken(token)) {
+			String username = jwtTokenProvider.getUsername(token);
+			UserDetails userDetails = userDetailsService.loadUserByUsername(username);
 
-            SecurityContextHolder.getContext().setAuthentication(auth);
-        }
+			UsernamePasswordAuthenticationToken auth =
+				new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
 
-        filterChain.doFilter(request, response);
-    }
+			SecurityContextHolder.getContext().setAuthentication(auth);
+		}
 
-    private String resolveToken(HttpServletRequest request) {
-        String bearer = request.getHeader(AUTHORIZATION_HEADER);
-        if (bearer != null && bearer.startsWith(BEARER_PREFIX)) {
-            return bearer.substring(7);
-        }
-        return null;
-    }
+		filterChain.doFilter(request, response);
+	}
+
+	private String resolveToken(HttpServletRequest request) {
+		String bearer = request.getHeader(AUTHORIZATION_HEADER);
+		if (bearer != null && bearer.startsWith(BEARER_PREFIX)) {
+			return bearer.substring(7);
+		}
+		return null;
+	}
 }

--- a/src/main/java/woojooin/planit/global/util/UrlEncodeUtil.java
+++ b/src/main/java/woojooin/planit/global/util/UrlEncodeUtil.java
@@ -1,0 +1,34 @@
+package woojooin.planit.global.util;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+
+public class UrlEncodeUtil {
+
+	private static String URL;
+
+	/**
+	 * URL 인코딩 문자열을 DTO로 변환하는 메서드
+	 *
+	 * @param encoded : url 인코딩된 문자열
+	 * @param typeReference : 변환할 타입
+	 * @param namingStrategy : 문자열의 네이밍 전략
+	 * @return : 제네릭 클래스로 직렬화된 DTO 객체
+	 * @param <T>
+	 */
+	public static <T> T decodeToDto(String encoded, TypeReference<T> typeReference,
+		PropertyNamingStrategy namingStrategy) {
+		try {
+			String decodedJson = URLDecoder.decode(encoded, StandardCharsets.UTF_8);
+			ObjectMapper objectMapper = new ObjectMapper();
+			objectMapper.setPropertyNamingStrategy(namingStrategy);
+			return objectMapper.readValue(decodedJson, typeReference);
+		} catch (Exception e) {
+			throw new RuntimeException("Decoding failed", e);
+		}
+	}
+}

--- a/src/main/java/woojooin/planit/global/util/codef/CodefAccountUtil.java
+++ b/src/main/java/woojooin/planit/global/util/codef/CodefAccountUtil.java
@@ -2,6 +2,7 @@ package woojooin.planit.global.util.codef;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
@@ -13,15 +14,27 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
+import com.github.benmanes.caffeine.cache.Cache;
+
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import woojooin.planit.global.util.codef.dto.AccountDto;
+import woojooin.planit.global.util.codef.dto.req.ConnectedIdReq;
 import woojooin.planit.global.util.codef.dto.res.CodefTokenRes;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class CodefAccountUtil {
+
+	private final Cache<String, CodefTokenRes> localCache;
+	private final RestTemplate restTemplate;
 
 	@Value("${codef.base-url}")
 	private String CODEF_URL;
+
+	@Value("${codef.api-url}")
+	private String CODEF_API_URL;
 
 	@Value("${codef.client.id}")
 	private String CODEF_CLIENT_ID;
@@ -32,13 +45,13 @@ public class CodefAccountUtil {
 	private final static String BASIC_PREFIX = "Basic ";
 	private final static String BEARER_PREFIX = "Bearer ";
 	private final static String AUTHORIZATION_HEADER = "Authorization";
+	private static final String TOKEN_CACHE_KEY = "codef_access_token";
 
 	/**
-	 * codef 사용자 응답 및 요청 데이터
+	 * codef token 발급 메서드
 	 * @return
 	 */
-	public CodefTokenRes getAccessToken() {
-		RestTemplate restTemplate = new RestTemplate();
+	private CodefTokenRes getAccessTokenFromCodef() {
 
 		String url = CODEF_URL + "/oauth/token";
 		String authKey = CODEF_CLIENT_ID + ":" + CODEF_CLIENT_SECRET;
@@ -61,8 +74,40 @@ public class CodefAccountUtil {
 			.getBody();
 	}
 
-	public static void registerConnectedId() {
+	/**
+	 * token값 반환 메서드
+	 * 토큰이 만료되었으면 재발급
+	 */
+	public CodefTokenRes getAccessToken() {
+		CodefTokenRes cachedToken = localCache.getIfPresent(TOKEN_CACHE_KEY);
+
+		if (cachedToken == null) {
+			cachedToken = getAccessTokenFromCodef();
+			localCache.put(TOKEN_CACHE_KEY, cachedToken);
+		}
+
+		return cachedToken;
+	}
+
+	/**
+	 * connected_id를 발급하기 위한 register 연동
+	 * AccountDto - 사용자의 실제 계좌 정보를 담은 객체
+	 * @param accountList
+	 */
+	public void registerConnectedId(List<AccountDto> accountList) {
 		RestTemplate restTemplate = new RestTemplate();
+
+		String url = CODEF_API_URL + "/v1/account/create";
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON);
+		headers.add(AUTHORIZATION_HEADER, BEARER_PREFIX + getAccessToken().accessToken());
+
+		ConnectedIdReq body = new ConnectedIdReq(accountList);
+
+		HttpEntity<ConnectedIdReq> entity = new HttpEntity<>(body, headers);
+
+		restTemplate.exchange(url, HttpMethod.POST, entity, CodefTokenRes.class);
 
 	}
 }

--- a/src/main/java/woojooin/planit/global/util/codef/CodefAccountUtil.java
+++ b/src/main/java/woojooin/planit/global/util/codef/CodefAccountUtil.java
@@ -4,23 +4,30 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.github.benmanes.caffeine.cache.Cache;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import woojooin.planit.global.util.codef.dto.AccountDto;
-import woojooin.planit.global.util.codef.dto.req.ConnectedIdReq;
+import woojooin.planit.global.util.UrlEncodeUtil;
+import woojooin.planit.global.util.codef.dto.req.connectedId.AccountDto;
+import woojooin.planit.global.util.codef.dto.req.connectedId.create.ConnectedIdCreateReq;
+import woojooin.planit.global.util.codef.dto.res.CodefResponse;
 import woojooin.planit.global.util.codef.dto.res.CodefTokenRes;
+import woojooin.planit.global.util.codef.dto.res.connectedId.ConntectedIdResData;
 
 @Slf4j
 @Component
@@ -28,7 +35,12 @@ import woojooin.planit.global.util.codef.dto.res.CodefTokenRes;
 public class CodefAccountUtil {
 
 	private final Cache<String, CodefTokenRes> localCache;
-	private final RestTemplate restTemplate;
+
+	@Qualifier("snakeRestTemplate")
+	private final RestTemplate snakeRestTemplate;
+
+	@Qualifier("camelRestTemplate")
+	private final RestTemplate camelRestTemplate;
 
 	@Value("${codef.base-url}")
 	private String CODEF_URL;
@@ -47,7 +59,11 @@ public class CodefAccountUtil {
 	private final static String AUTHORIZATION_HEADER = "Authorization";
 	private static final String TOKEN_CACHE_KEY = "codef_access_token";
 
+	public static PropertyNamingStrategy SNAKE = PropertyNamingStrategy.SNAKE_CASE;
+	public static PropertyNamingStrategy CAMEL = PropertyNamingStrategy.LOWER_CAMEL_CASE;
+
 	/**
+	 * codef_path : /oauth/token
 	 * codef token 발급 메서드
 	 * @return
 	 */
@@ -70,7 +86,7 @@ public class CodefAccountUtil {
 		body.add("scope", "read");
 
 		//HTTP POST 요청 및 응답
-		return restTemplate.exchange(url, HttpMethod.POST, new HttpEntity<>(body, headers), CodefTokenRes.class)
+		return snakeRestTemplate.exchange(url, HttpMethod.POST, new HttpEntity<>(body, headers), CodefTokenRes.class)
 			.getBody();
 	}
 
@@ -90,24 +106,34 @@ public class CodefAccountUtil {
 	}
 
 	/**
-	 * connected_id를 발급하기 위한 register 연동
+	 * codef_path : /v1/account/create
+	 * connected_id를 발급하기 위한 user register 기능
 	 * AccountDto - 사용자의 실제 계좌 정보를 담은 객체
 	 * @param accountList
 	 */
-	public void registerConnectedId(List<AccountDto> accountList) {
-		RestTemplate restTemplate = new RestTemplate();
-
+	public ConntectedIdResData registerConnectedId(List<AccountDto> accountList) {
 		String url = CODEF_API_URL + "/v1/account/create";
 
 		HttpHeaders headers = new HttpHeaders();
 		headers.setContentType(MediaType.APPLICATION_JSON);
 		headers.add(AUTHORIZATION_HEADER, BEARER_PREFIX + getAccessToken().accessToken());
 
-		ConnectedIdReq body = new ConnectedIdReq(accountList);
+		ConnectedIdCreateReq body = new ConnectedIdCreateReq(accountList);
+		HttpEntity<ConnectedIdCreateReq> entity = new HttpEntity<>(body, headers);
 
-		HttpEntity<ConnectedIdReq> entity = new HttpEntity<>(body, headers);
+		ResponseEntity<String> responseEntity = camelRestTemplate.exchange(
+			url,
+			HttpMethod.POST,
+			entity,
+			String.class
+		);
 
-		restTemplate.exchange(url, HttpMethod.POST, entity, CodefTokenRes.class);
+		String resString = responseEntity.getBody();
+		TypeReference<CodefResponse<ConntectedIdResData>> type = new TypeReference<CodefResponse<ConntectedIdResData>>() {
+		};
 
+		CodefResponse<ConntectedIdResData> res = UrlEncodeUtil.decodeToDto(resString, type, CAMEL);
+
+		return res.getData();
 	}
 }

--- a/src/main/java/woojooin/planit/global/util/codef/CodefAccountUtil.java
+++ b/src/main/java/woojooin/planit/global/util/codef/CodefAccountUtil.java
@@ -1,0 +1,68 @@
+package woojooin.planit.global.util.codef;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import lombok.extern.slf4j.Slf4j;
+import woojooin.planit.global.util.codef.dto.res.CodefTokenRes;
+
+@Slf4j
+@Component
+public class CodefAccountUtil {
+
+	@Value("${codef.base-url}")
+	private String CODEF_URL;
+
+	@Value("${codef.client.id}")
+	private String CODEF_CLIENT_ID;
+
+	@Value("${codef.client.secret}")
+	private String CODEF_CLIENT_SECRET;
+
+	private final static String BASIC_PREFIX = "Basic ";
+	private final static String BEARER_PREFIX = "Bearer ";
+	private final static String AUTHORIZATION_HEADER = "Authorization";
+
+	/**
+	 * codef 사용자 응답 및 요청 데이터
+	 * @return
+	 */
+	public CodefTokenRes getAccessToken() {
+		RestTemplate restTemplate = new RestTemplate();
+
+		String url = CODEF_URL + "/oauth/token";
+		String authKey = CODEF_CLIENT_ID + ":" + CODEF_CLIENT_SECRET;
+		String encodedAuthKey = Base64.getEncoder().encodeToString(authKey.getBytes(StandardCharsets.UTF_8));
+
+		log.info("authKey = {}", encodedAuthKey);
+
+		//header 값 세팅
+		HttpHeaders headers = new HttpHeaders();
+		headers.set(AUTHORIZATION_HEADER, BASIC_PREFIX + encodedAuthKey);
+		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+		//body 값 세팅
+		MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+		body.add("grant_type", "client_credentials");
+		body.add("scope", "read");
+
+		//HTTP POST 요청 및 응답
+		return restTemplate.exchange(url, HttpMethod.POST, new HttpEntity<>(body, headers), CodefTokenRes.class)
+			.getBody();
+	}
+
+	public static void registerConnectedId() {
+		RestTemplate restTemplate = new RestTemplate();
+
+	}
+}

--- a/src/main/java/woojooin/planit/global/util/codef/dto/req/connectedId/AccountDto.java
+++ b/src/main/java/woojooin/planit/global/util/codef/dto/req/connectedId/AccountDto.java
@@ -1,0 +1,26 @@
+package woojooin.planit.global.util.codef.dto.req.connectedId;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class AccountDto {
+	private String countryCode;
+
+	private String businessType;
+
+	private String clientType;
+
+	private String organization;
+
+	private String loginType;
+
+	private String id;
+
+	private String password;
+
+	private String birthDate;
+}

--- a/src/main/java/woojooin/planit/global/util/codef/dto/req/connectedId/create/ConnectedIdCreateReq.java
+++ b/src/main/java/woojooin/planit/global/util/codef/dto/req/connectedId/create/ConnectedIdCreateReq.java
@@ -1,0 +1,9 @@
+package woojooin.planit.global.util.codef.dto.req.connectedId.create;
+
+import java.util.List;
+
+import woojooin.planit.global.util.codef.dto.req.connectedId.AccountDto;
+
+public record ConnectedIdCreateReq(List<AccountDto> accountList) {
+
+}

--- a/src/main/java/woojooin/planit/global/util/codef/dto/res/CodefResponse.java
+++ b/src/main/java/woojooin/planit/global/util/codef/dto/res/CodefResponse.java
@@ -1,0 +1,18 @@
+package woojooin.planit.global.util.codef.dto.res;
+
+import lombok.Getter;
+
+@Getter
+public class CodefResponse<T> {
+	private CodefResult result;
+	private T data;
+
+	@Getter
+	public static class CodefResult {
+		private String code;
+		private String extraMessage;
+		private String message;
+		private String transactionId;
+	}
+
+}

--- a/src/main/java/woojooin/planit/global/util/codef/dto/res/CodefTokenRes.java
+++ b/src/main/java/woojooin/planit/global/util/codef/dto/res/CodefTokenRes.java
@@ -1,0 +1,12 @@
+package woojooin.planit.global.util.codef.dto.res;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record CodefTokenRes(
+	@JsonProperty("access_token") String accessToken,
+	@JsonProperty("token_type") String tokenType,
+	@JsonProperty("expires_in") Integer expiresIn,
+	@JsonProperty("scope") String scope
+) {
+}
+

--- a/src/main/java/woojooin/planit/global/util/codef/dto/res/CodefTokenRes.java
+++ b/src/main/java/woojooin/planit/global/util/codef/dto/res/CodefTokenRes.java
@@ -1,12 +1,10 @@
 package woojooin.planit.global.util.codef.dto.res;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 public record CodefTokenRes(
-	@JsonProperty("access_token") String accessToken,
-	@JsonProperty("token_type") String tokenType,
-	@JsonProperty("expires_in") Integer expiresIn,
-	@JsonProperty("scope") String scope
+	String accessToken,
+	String tokenType,
+	Integer expiresIn,
+	String scope
 ) {
 }
 

--- a/src/main/java/woojooin/planit/global/util/codef/dto/res/connectedId/ConntectedIdResData.java
+++ b/src/main/java/woojooin/planit/global/util/codef/dto/res/connectedId/ConntectedIdResData.java
@@ -1,0 +1,26 @@
+package woojooin.planit.global.util.codef.dto.res.connectedId;
+
+import java.util.List;
+
+import lombok.Data;
+
+@Data
+public class ConntectedIdResData {
+
+	private List<SuccessItem> successList;
+	private List<Object> errorList;
+	private String connectedId;
+
+	@Data
+	public static class SuccessItem {
+		private String clientType;
+		private String code;
+		private String loginType;
+		private String countryCode;
+		private String organization;
+		private String extraMessage;
+		private String businessType;
+		private String message;
+		private String transactionId;
+	}
+}


### PR DESCRIPTION
## 🔖 PR 유형
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
codef 및 openData 연동을 위한 인프라 및 유틸리티 기능을 추가하였습니다. RestTemplate 네이밍 전략별 분리, 스레드풀 설정, URL 인코딩 파싱 유틸리티 등 다양한 인프라 개선 작업을 포함합니다.

## 🔧 작업 내용
- codef 연동 테스트용 `CodefTestController` 추가
- codef 관련 요청/응답 DTO 클래스 추가 (`ConntedIdAddReq`, `ConnectedIdCreateReq`, `AccountDto` 등)
- codef 계정 연동 유틸리티(`CodefAccountUtil`) 및 토큰/응답 DTO 추가
- openData 연동을 위한 `OpenApiUtil` 클래스 추가
- **RestTemplate을 네이밍 전략별로 분리하여 관리하도록 설정**
- **비동기 처리를 위한 스레드풀(Executor) 설정 추가**
- **URL 인코딩된 문자열을 TypeReference를 활용해 DTO로 변환하는 유틸리티 메서드 구현**

## ✅ 체크리스트
- [X] 테스트 완료(Postman)

## 📝 기타 참고 사항
> access token 발급
<img width="1480" height="806" alt="image" src="https://github.com/user-attachments/assets/2c9242d2-667f-4747-8633-32d0684e12b5" />

</br>  

> connteced_id 발급
<img width="1221" height="840" alt="image" src="https://github.com/user-attachments/assets/f843fcd9-f3af-4915-9dd6-147c49887a08" />


## 📎 관련 이슈
#9 
