### PR TITLE
[Feature] - 투자 위험성 기반 상품 추천 API 구현

### DIFF
--- a/src/main/java/woojooin/planit/domain/product/controller/ProductController.java
+++ b/src/main/java/woojooin/planit/domain/product/controller/ProductController.java
@@ -26,6 +26,6 @@ public class ProductController {
 	public Response<List<Product>> getRecommendedProducts() {
 		String userRiskLevel = "SAFE"; // 임시로 하드코딩한 값
 		List<Product> recommendedProducts = productService.recommendProduct(userRiskLevel);
-		return Response.ok(recommendedProducts); // Response 객체로 감싸서 반환
+		return Response.ok(recommendedProducts);
 	}
 }

--- a/src/main/java/woojooin/planit/domain/product/controller/ProductController.java
+++ b/src/main/java/woojooin/planit/domain/product/controller/ProductController.java
@@ -13,7 +13,7 @@ import woojooin.planit.domain.product.domain.Product;
 import woojooin.planit.domain.product.service.ProductService;
 
 @RestController
-@RequestMapping("/api/products")
+@RequestMapping("/auth/api/products")
 @Api(value = "Product API", description = "상품 추천 API")
 @RequiredArgsConstructor
 public class ProductController {

--- a/src/main/java/woojooin/planit/domain/product/controller/ProductController.java
+++ b/src/main/java/woojooin/planit/domain/product/controller/ProductController.java
@@ -1,0 +1,29 @@
+package woojooin.planit.domain.product.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import woojooin.planit.domain.product.domain.Product;
+import woojooin.planit.domain.product.service.ProductService;
+
+@RestController
+@RequestMapping("/api/products")
+@Api(value = "Product API", description = "상품 추천 API")
+@RequiredArgsConstructor
+public class ProductController {
+
+	private final ProductService productService;
+
+	@GetMapping("/recommend")
+	@ApiOperation(value = "추천 상품 조회", notes = "사용자의 투자 위험성에 맞는 추천 상품 목록을 반환합니다.")
+	public List<Product> getRecommendedProducts() {
+		String userRiskLevel = "SAFE";
+		return productService.recommendProduct(userRiskLevel);
+	}
+}

--- a/src/main/java/woojooin/planit/domain/product/controller/ProductController.java
+++ b/src/main/java/woojooin/planit/domain/product/controller/ProductController.java
@@ -11,6 +11,7 @@ import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import woojooin.planit.domain.product.domain.Product;
 import woojooin.planit.domain.product.service.ProductService;
+import woojooin.planit.global.response.Response;
 
 @RestController
 @RequestMapping("/auth/api/products")
@@ -22,8 +23,9 @@ public class ProductController {
 
 	@GetMapping("/recommend")
 	@ApiOperation(value = "추천 상품 조회", notes = "사용자의 투자 위험성에 맞는 추천 상품 목록을 반환합니다.")
-	public List<Product> getRecommendedProducts() {
-		String userRiskLevel = "SAFE";
-		return productService.recommendProduct(userRiskLevel);
+	public Response<List<Product>> getRecommendedProducts() {
+		String userRiskLevel = "SAFE"; // 임시로 하드코딩한 값
+		List<Product> recommendedProducts = productService.recommendProduct(userRiskLevel);
+		return Response.ok(recommendedProducts); // Response 객체로 감싸서 반환
 	}
 }

--- a/src/main/java/woojooin/planit/domain/product/mapper/ProductMapper.java
+++ b/src/main/java/woojooin/planit/domain/product/mapper/ProductMapper.java
@@ -1,7 +1,11 @@
 package woojooin.planit.domain.product.mapper;
 
+import java.util.List;
+
 import woojooin.planit.domain.product.domain.Product;
 
 public interface ProductMapper {
 	void insertProduct(Product product);
+	void deleteAll();
+	List<Product> selectByRiskLevel(String riskLevel);
 }

--- a/src/main/java/woojooin/planit/domain/product/service/ProductService.java
+++ b/src/main/java/woojooin/planit/domain/product/service/ProductService.java
@@ -1,11 +1,15 @@
 package woojooin.planit.domain.product.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import woojooin.planit.domain.product.domain.Product;
 import woojooin.planit.domain.product.mapper.ProductMapper;
+import woojooin.planit.global.exception.BusinessException;
+import woojooin.planit.global.response.ResponseCode;
 import woojooin.planit.global.util.openData.OpenApiUtil;
 import woojooin.planit.global.util.openData.dto.OpenApiResponse;
 import woojooin.planit.global.util.openData.dto.price.etf.ETFPriceRes;
@@ -30,6 +34,20 @@ public class ProductService {
 			mapper.insertProduct(product);
 		}
 	}
+
+	public void deleteAllProducts() {
+		mapper.deleteAll();
+	}
+
+
+	public List<Product> recommendProduct(String riskLevel) {
+		List<Product> products = mapper.selectByRiskLevel(riskLevel);
+		if (products == null || products.isEmpty()) {
+			throw new BusinessException(ResponseCode.ISA_PRODUCT_NOT_FOUND);
+		}
+		return products;
+	}
+
 
 	private boolean isValidResponse(OpenApiResponse<ETFPriceRes> response) {
 		return response != null &&

--- a/src/main/java/woojooin/planit/global/util/openData/dto/price/etf/ETFPriceRes.java
+++ b/src/main/java/woojooin/planit/global/util/openData/dto/price/etf/ETFPriceRes.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.Data;
 import woojooin.planit.domain.product.domain.Product;
+import woojooin.planit.domain.product.domain.RiskLevel;
 
 @Data
 public class ETFPriceRes {
@@ -96,7 +97,7 @@ public class ETFPriceRes {
 		product.setLstgStCnt(item.getStLstgCnt());
 		product.setMrktTotAmt(item.getMrktTotAmt());
 
-		product.setRiskLevel(null);
+		product.setRiskLevel(String.valueOf(RiskLevel.SAFE));
 
 		return product;
 	}

--- a/src/main/resources/mapper/ProductMapper.xml
+++ b/src/main/resources/mapper/ProductMapper.xml
@@ -22,16 +22,30 @@
     </resultMap>
 
     <insert id="insertProduct" parameterType="woojooin.planit.domain.product.domain.Product">
-        INSERT INTO product (
-            srtn_cd, isin_cd, itms_nm, bas_dt, clpr, vs, flt_rt,
-            mkp, hipr, lopr, trqu, tr_prc, lstg_st_cnt, mrkt_tot_amt,
-            risk_level
-        )
-        VALUES (
-                   #{srtnCd}, #{isinCd}, #{itmsNm}, #{basDt}, #{clpr}, #{vs}, #{fltRt},
-                   #{mkp}, #{hipr}, #{lopr}, #{trqu}, #{trPrc}, #{lstgStCnt}, #{mrktTotAmt},
-                   #{riskLevel}
-               )
+        INSERT INTO product (srtn_cd, isin_cd, itms_nm, bas_dt, clpr, vs, flt_rt,
+                             mkp, hipr, lopr, trqu, tr_prc, lstg_st_cnt, mrkt_tot_amt,
+                             risk_level)
+        VALUES (#{srtnCd}, #{isinCd}, #{itmsNm}, #{basDt}, #{clpr}, #{vs}, #{fltRt},
+                #{mkp}, #{hipr}, #{lopr}, #{trqu}, #{trPrc}, #{lstgStCnt}, #{mrktTotAmt},
+                #{riskLevel})
     </insert>
+
+
+    <delete id="deleteAll">
+        DELETE
+        FROM product
+    </delete>
+
+
+    <select id="selectByRiskLevel" resultMap="productResultMap">
+        SELECT p.*
+        FROM product p
+                 INNER JOIN (SELECT srtn_cd, MAX(bas_dt) AS max_bas_dt
+                             FROM product
+                             WHERE risk_level = #{riskLevel}
+                             GROUP BY srtn_cd) sub ON p.srtn_cd = sub.srtn_cd AND p.bas_dt = sub.max_bas_dt
+        WHERE p.risk_level = #{riskLevel}
+        ORDER BY CAST(p.flt_rt AS DECIMAL(10, 4)) DESC
+    </select>
 
 </mapper>


### PR DESCRIPTION
## 🔖 PR 유형
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
사용자 투자 위험성에 따른 금융 상품 추천 API를 구현하고, 최신 데이터 조회 쿼리 및 예외 처리를 추가했습니다

## 🔧 작업 내용
- ProductController에 투자 위험성별 추천 상품 조회 API 엔드포인트 추가

- Swagger 2 어노테이션으로 API 문서화하여 API 명세 제공

- ProductService에서 추천 상품 조회 로직 구현 및 결과 없을 경우 BusinessException 예외 처리 추가

- ProductMapper 인터페이스에 위험성별 최신 상품 조회 메서드 정의

- ProductMapper.xml 매퍼 파일에서 resultMap 사용하도록 수정, 쿼리 문법 오류 수정 및 최신 날짜 기준 등락률 내림차순 정렬 쿼리 작성

전체 기능에 대한 통합 테스트 및 예외처리 정상 동작 확인
## ✅ 체크리스트
- [x] 테스트 완료(Postman, Swagger)

## 📝 기타 참고 사항

<img width="794" height="940" alt="image" src="https://github.com/user-attachments/assets/ba9ad6f3-9ced-4e58-817f-8d7153ac8d28" />


## 📎 관련 이슈
Close #28 
