### PR TITLE
[FEAT #69]: 사용자의 투자성향 검사 점수 조회 api

### DIFF
--- a/src/main/java/woojooin/planit/domain/member/controller/MemberApiController.java
+++ b/src/main/java/woojooin/planit/domain/member/controller/MemberApiController.java
@@ -1,17 +1,23 @@
 package woojooin.planit.domain.member.controller;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
-import woojooin.planit.domain.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import woojooin.planit.domain.member.dto.res.InvestScoreRes;
 import woojooin.planit.domain.member.service.MemberService;
+import woojooin.planit.global.response.Response;
 import woojooin.planit.global.security.CustomUserDetails;
 
 @RestController
-@RequestMapping("/api/member")
+@RequestMapping("/auth/api/member")
 @RequiredArgsConstructor
 @Api(value = "회원 API", description = "회원 관련 API")
 public class MemberApiController {
@@ -34,11 +40,19 @@ public class MemberApiController {
     @ApiOperation(value = "회원 투자 성향 저장", notes = "로그인 유저의 투자 성향 저장")
     public ResponseEntity<Void> saveInvestType(
             @RequestParam String type,
-            @AuthenticationPrincipal CustomUserDetails user // 네 프로젝트의 Principal 타입
+            @AuthenticationPrincipal CustomUserDetails user
     ) {
         Long memberId = user.getId();
         memberService.updateInvestType(memberId, type);
         return ResponseEntity.ok().build();
     }
 
+    @GetMapping("/invest-score")
+    @ApiOperation(value = "회원 투자 성향 점수 조회", notes = "회원 투자 성향 점수 조회")
+    public ResponseEntity<Response<InvestScoreRes>> getInvestScore(
+        @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        InvestScoreRes investScore = memberService.getInvestScore(customUserDetails.getId());
+        return ResponseEntity.ok(Response.ok(investScore));
+    }
 }

--- a/src/main/java/woojooin/planit/domain/member/domain/Member.java
+++ b/src/main/java/woojooin/planit/domain/member/domain/Member.java
@@ -1,11 +1,9 @@
 package woojooin.planit.domain.member.domain;
 
-import lombok.AccessLevel;
-import lombok.Builder;
+import java.time.LocalDateTime;
+
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Data
 @NoArgsConstructor
@@ -23,5 +21,9 @@ public class Member {
     private Boolean benefit;
     private String nickname;
     private Boolean isAgreed;
-
+    private Double stable;
+    private Double income;
+    private Double liquid;
+    private Double growth;
+    private Double diversified;
 }

--- a/src/main/java/woojooin/planit/domain/member/dto/req/RealInvestTypeReq.java
+++ b/src/main/java/woojooin/planit/domain/member/dto/req/RealInvestTypeReq.java
@@ -1,0 +1,73 @@
+package woojooin.planit.domain.member.dto.req;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RealInvestTypeReq {
+	private String investType;      // ex: "보수형", "안정형", "위험중립형", "성장형", "공격형"
+	private Double stable;
+	private Double income;
+	private Double liquid;
+	private Double growth;
+	private Double diversified;
+	
+	public static String convertInvestType(String englishType) {
+		if (englishType == null) {
+			return "공격형";
+		}
+		switch (englishType) {
+			case "CONSERVATIVE":
+				return "보수형";
+			case "STABLE":
+				return "안정형";
+			case "NEUTRAL":
+				return "위험중립형";
+			case "GROWTH":
+				return "성장형";
+			case "AGGRESSIVE":
+			default:
+				return "공격형";
+		}
+	}
+	
+	public static String determineInvestTypeByScore(Double stable, Double income, Double liquid, Double growth, Double diversified) {
+		if (stable == null && income == null && liquid == null && growth == null && diversified == null) {
+			return "공격형";
+		}
+		
+		Double maxScore = 0.0;
+		String investType = "공격형";
+		
+		if (stable != null && stable > maxScore) {
+			maxScore = stable;
+			investType = "안정형";
+		}
+		if (income != null && income > maxScore) {
+			maxScore = income;
+			investType = "수익형";
+		}
+		if (liquid != null && liquid > maxScore) {
+			maxScore = liquid;
+			investType = "유동형";
+		}
+		if (growth != null && growth > maxScore) {
+			maxScore = growth;
+			investType = "성장형";
+		}
+		if (diversified != null && diversified > maxScore) {
+			maxScore = diversified;
+			investType = "분산형";
+		}
+		
+		return investType;
+	}
+	
+	public static RealInvestTypeReq fromScores(Double stable, Double income, Double liquid, Double growth, Double diversified) {
+		String investType = determineInvestTypeByScore(stable, income, liquid, growth, diversified);
+		return new RealInvestTypeReq(investType, stable, income, liquid, growth, diversified);
+	}
+}

--- a/src/main/java/woojooin/planit/domain/member/dto/res/InvestScoreRes.java
+++ b/src/main/java/woojooin/planit/domain/member/dto/res/InvestScoreRes.java
@@ -1,0 +1,16 @@
+package woojooin.planit.domain.member.dto.res;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import woojooin.planit.domain.member.dto.req.RealInvestTypeReq;
+import woojooin.planit.domain.openAi.dto.req.DefaultInvestTypeReq;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class InvestScoreRes {
+    private Long memberId;
+    private DefaultInvestTypeReq surveyInvestmentType;
+    private RealInvestTypeReq realInvestType;
+}

--- a/src/main/java/woojooin/planit/domain/member/service/MemberService.java
+++ b/src/main/java/woojooin/planit/domain/member/service/MemberService.java
@@ -2,6 +2,7 @@ package woojooin.planit.domain.member.service;
 
 
 import woojooin.planit.domain.member.domain.Member;
+import woojooin.planit.domain.member.dto.res.InvestScoreRes;
 
 public interface MemberService {
     Member findById(Long memberId);
@@ -9,4 +10,6 @@ public interface MemberService {
     void save(Member member);
     void update(Member member);
     void updateInvestType(Long memberId, String type);
+
+	InvestScoreRes getInvestScore(Long id);
 }

--- a/src/main/java/woojooin/planit/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/woojooin/planit/domain/member/service/MemberServiceImpl.java
@@ -3,7 +3,10 @@ package woojooin.planit.domain.member.service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import woojooin.planit.domain.member.domain.Member;
+import woojooin.planit.domain.member.dto.req.RealInvestTypeReq;
+import woojooin.planit.domain.member.dto.res.InvestScoreRes;
 import woojooin.planit.domain.member.repository.MemberRepository;
+import woojooin.planit.domain.openAi.dto.req.DefaultInvestTypeReq;
 
 @Service
 public class MemberServiceImpl implements MemberService {
@@ -32,5 +35,25 @@ public class MemberServiceImpl implements MemberService {
     @Override
     public void updateInvestType(Long memberId, String type) {
         memberRepository.updateInvestType(memberId, type);
+    }
+
+    @Override
+    public InvestScoreRes getInvestScore(Long id) {
+        Member member = memberRepository.findById(id);
+        if (member == null) {
+            return null;
+        }
+
+        DefaultInvestTypeReq surveyInvestmentType = DefaultInvestTypeReq.getInvestType(member.getInvestType());
+        
+        RealInvestTypeReq realInvestType = RealInvestTypeReq.fromScores(
+            member.getStable(),
+            member.getIncome(),
+            member.getLiquid(),
+            member.getGrowth(),
+            member.getDiversified()
+        );
+
+        return new InvestScoreRes(id, surveyInvestmentType, realInvestType);
     }
 }

--- a/src/main/java/woojooin/planit/domain/openAi/dto/req/DefaultInvestTypeReq.java
+++ b/src/main/java/woojooin/planit/domain/openAi/dto/req/DefaultInvestTypeReq.java
@@ -40,4 +40,18 @@ public class DefaultInvestTypeReq {
         // 공격형: 안정성 10, 수익성 35, 유동성 10, 성장성 35, 분산투자 10
         return new DefaultInvestTypeReq("공격형", 10.0, 35.0, 10.0, 35.0, 10.0);
     }
+
+    public static DefaultInvestTypeReq getInvestType(String investType){
+        if (investType.equals("GROWTH")) {
+            return growth();
+        } else if (investType.equals("NEUTRAL")) {
+            return neutral();
+        } else if (investType.equals("STABLE")) {
+            return stable();
+        } else if (investType.equals("CONSERVATIVE")) {
+            return conservative();
+        }else{
+            return aggressive();
+        }
+    }
 }


### PR DESCRIPTION
## 🔖 PR 유형
- [X] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
- 사용자의 투자성향 검사 점수 조회 api

<img width="1440" height="900" alt="스크린샷 2025-08-11 오전 11 11 37" src="https://github.com/user-attachments/assets/889f3ba1-314e-4226-ab2d-d7fc3df8353c" />

## 📎 관련 이슈
Close #69 
