### PR TITLE
[FEAT] REPORT 수익률 막대그래프 API

### DIFF
--- a/src/main/java/woojooin/planit/domain/member/controller/MemberApiController.java
+++ b/src/main/java/woojooin/planit/domain/member/controller/MemberApiController.java
@@ -6,9 +6,14 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import woojooin.planit.domain.goal.domain.Goal;
+import woojooin.planit.domain.goal.dto.GoalRequestDto;
 import woojooin.planit.domain.member.domain.Member;
 import woojooin.planit.domain.member.service.MemberService;
+import woojooin.planit.global.response.Response;
 import woojooin.planit.global.security.CustomUserDetails;
+
+import javax.validation.Valid;
 
 @RestController
 @RequestMapping("/api/member")
@@ -29,16 +34,13 @@ public class MemberApiController {
         return "Member API OK";
     }
 
-
     @PostMapping("/invest-type")
     @ApiOperation(value = "회원 투자 성향 저장", notes = "로그인 유저의 투자 성향 저장")
-    public ResponseEntity<Void> saveInvestType(
+    public ResponseEntity<Response<Void>> saveInvestType(
             @RequestParam String type,
-            @AuthenticationPrincipal CustomUserDetails user // 네 프로젝트의 Principal 타입
-    ) {
+            @AuthenticationPrincipal CustomUserDetails user) {
         Long memberId = user.getId();
         memberService.updateInvestType(memberId, type);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(Response.ok());
     }
-
 }

--- a/src/main/java/woojooin/planit/domain/report/controller/ReportController.java
+++ b/src/main/java/woojooin/planit/domain/report/controller/ReportController.java
@@ -1,0 +1,50 @@
+package woojooin.planit.domain.report.controller;
+
+
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import woojooin.planit.domain.report.domain.ReturnRateDto;
+import woojooin.planit.domain.report.domain.ReturnType;
+import woojooin.planit.domain.report.service.ReportService;
+import woojooin.planit.global.response.Response;
+import woojooin.planit.global.security.CustomUserDetails;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/reports")
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @GetMapping("returns")
+    @ApiOperation(value = "수익률 막대그래프 조회" , notes = "일별 , 주간 , 월별 수익률 데이터를 조회합니다.")
+    public  ResponseEntity<Response<List<ReturnRateDto>>> getReturnRateByType(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam("type")ReturnType returnType,
+            @RequestParam(value = "startDate" , required = false)
+            @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate){
+
+        Long memberId = userDetails.getId();
+        List<ReturnRateDto> returnRates = reportService.getReturnRateByType(memberId, returnType, startDate);
+        return ResponseEntity.ok(Response.ok(returnRates));
+    }
+}
+
+
+
+
+
+
+
+
+

--- a/src/main/java/woojooin/planit/domain/report/domain/ReturnRateDto.java
+++ b/src/main/java/woojooin/planit/domain/report/domain/ReturnRateDto.java
@@ -1,0 +1,16 @@
+package woojooin.planit.domain.report.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReturnRateDto {
+    private LocalDate date;
+    private BigDecimal rate ;
+}

--- a/src/main/java/woojooin/planit/domain/report/domain/ReturnType.java
+++ b/src/main/java/woojooin/planit/domain/report/domain/ReturnType.java
@@ -1,0 +1,7 @@
+package woojooin.planit.domain.report.domain;
+
+public enum ReturnType {
+    DAILY,
+    WEEKLY,
+    MONTHLY
+}

--- a/src/main/java/woojooin/planit/domain/report/mapper/ReportMapper.java
+++ b/src/main/java/woojooin/planit/domain/report/mapper/ReportMapper.java
@@ -1,0 +1,19 @@
+package woojooin.planit.domain.report.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import woojooin.planit.domain.report.domain.ReturnRateDto;
+import woojooin.planit.domain.report.domain.ReturnType;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Mapper
+public interface ReportMapper {
+    List<ReturnRateDto> findReturnRateByType(
+            @Param("memberId") Long memberId,
+            @Param("returnType") ReturnType returnType,
+            @Param("startDate")LocalDate startDate
+    );
+
+}

--- a/src/main/java/woojooin/planit/domain/report/service/ReportService.java
+++ b/src/main/java/woojooin/planit/domain/report/service/ReportService.java
@@ -1,0 +1,23 @@
+package woojooin.planit.domain.report.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import woojooin.planit.domain.report.domain.ReturnRateDto;
+import woojooin.planit.domain.report.domain.ReturnType;
+import woojooin.planit.domain.report.mapper.ReportMapper;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+    private final ReportMapper reportMapper;
+
+    @Transactional(readOnly = true)
+    public List<ReturnRateDto>getReturnRateByType(Long memberId, ReturnType returnType, LocalDate startDate){
+        return reportMapper.findReturnRateByType(memberId, returnType, startDate);
+    }
+}

--- a/src/main/java/woojooin/planit/global/config/RootConfig.java
+++ b/src/main/java/woojooin/planit/global/config/RootConfig.java
@@ -36,7 +36,8 @@ import javax.sql.DataSource;
         "woojooin.planit.domain.goal.mapper", // Goal mapper 추가
         "woojooin.planit.domain.goal.goalAccount.mapper",  // GoalAccount mapper 추가
         "woojooin.planit.domain.account.mapper",// Account mapper 추가
-        "woojooin.planit.domain.openAi.mapper" // OpenAI mapper 추가
+        "woojooin.planit.domain.openAi.mapper" ,// OpenAI mapper 추가
+        "woojooin.planit.domain.report.mapper" // report mapper 추가
 })
 @Slf4j
 @EnableTransactionManagement

--- a/src/main/resources/mapper/report/ReportMapper.xml
+++ b/src/main/resources/mapper/report/ReportMapper.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace= "woojooin.planit.domain.report.mapper.ReportMapper">
+
+<select id="findReturnRateByType" resultType="woojooin.planit.domain.report.domain.ReturnRateDto">
+    select
+        return_date AS date,
+        return_rate AS rate
+    from investment_return
+    where member_id=#{memberId}
+      AND return_type = #{returnType}
+    <if test="startDate != null">
+        AND return_date &lt;= #{startDate}
+    </if>
+    ORDER BY return_date DESC
+        LIMIT 7
+</select>
+</mapper>


### PR DESCRIPTION
## 🔖 PR 유형
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
리포트 페이지 수익률 막대그래프 불러오기 API 


## 🔧 작업 내용
-  query로 (일,주,월)  / day 입력
- day  미입력시 최근 7개 (일,주,월) 보여주고 입력시 전 7(일, 주,월) 보여주기 

## ✅ 체크리스트
- [x] 테스트 완료(Postman, Swagger)
<img width="1031" height="1327" alt="image" src="https://github.com/user-attachments/assets/7a9e0304-dc3a-4ef4-bebe-5316ac2c8786" />
<img width="1205" height="1270" alt="image" src="https://github.com/user-attachments/assets/f9950725-4fa8-40af-ad2a-b0782244b44f" />
<img width="720" height="1117" alt="image" src="https://github.com/user-attachments/assets/ee20e5f4-c4ee-4693-af26-eabab120d5ae" />

## 📝 기타 참고 사항
- 주의할 점, 추후 리팩토링 필요성 등

## 📎 관련 이슈
Close #이슈번호
