### PR TITLE
feat:Tax비교 api 생성

### DIFF
--- a/src/main/java/woojooin/planit/domain/tax/controller/TaxComparisonController.java
+++ b/src/main/java/woojooin/planit/domain/tax/controller/TaxComparisonController.java
@@ -1,0 +1,41 @@
+package woojooin.planit.domain.tax.controller;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import woojooin.planit.domain.tax.dto.TaxComparisonRes;
+import woojooin.planit.domain.tax.service.TaxComparisonService;
+import woojooin.planit.global.response.Response;
+import woojooin.planit.global.response.ResponseCode;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/tax")
+@RequiredArgsConstructor
+@Api(value = "Tax Comparison API", description = "세금 비교 관련 API")
+public class TaxComparisonController {
+    
+    private final TaxComparisonService taxComparisonService;
+    
+    @GetMapping("/comparison/{memberId}/trend")
+    @ApiOperation(value = "세금 시계열 비교", notes = "특정 회원의 분기별 세금 비교 시계열 데이터를 조회합니다.")
+    public ResponseEntity<Response<TaxComparisonRes>> getTaxTrend(
+            @ApiParam(value = "회원 ID", required = true) @PathVariable Long memberId,
+            @ApiParam(value = "조회할 분기 수", required = false) @RequestParam(defaultValue = "8") Integer quarters) {
+        
+        log.info("Tax trend request for member: {}, quarters: {}", memberId, quarters);
+        
+        try {
+            TaxComparisonRes response = taxComparisonService.getTaxTrend(memberId, quarters);
+            return ResponseEntity.ok(Response.ok(response));
+        } catch (Exception e) {
+            log.error("Error occurred while getting tax trend for member: {}", memberId, e);
+            return ResponseEntity.internalServerError()
+                .body(Response.<TaxComparisonRes>build(null, ResponseCode.INTERNAL_ERROR));
+        }
+    }
+}

--- a/src/main/java/woojooin/planit/domain/tax/dto/TaxComparisonRes.java
+++ b/src/main/java/woojooin/planit/domain/tax/dto/TaxComparisonRes.java
@@ -1,0 +1,53 @@
+package woojooin.planit.domain.tax.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TaxComparisonRes {
+    
+    private List<QuarterlyTaxData> quarterlyData;
+    private TaxSummary summary;
+    
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class QuarterlyTaxData {
+        private String quarter;                 // 분기 (예: "2024-Q1")
+        
+        // ISA 관련
+        private BigDecimal isaProfit;           // ISA 수익
+        private BigDecimal isaGeneralTax;       // 일반 투자 시 세금
+        private BigDecimal isaTaxSaved;         // ISA 절세 금액
+        
+        // 예적금 관련  
+        private BigDecimal depositInterest;     // 예적금 이자수익
+        private BigDecimal depositTax;          // 예적금 세금 (소득세+지방소득세)
+        private BigDecimal depositNetIncome;    // 예적금 세후수익
+        
+        // 비교
+        private BigDecimal totalTaxDifference;  // 전체 세금 차이
+        private BigDecimal taxSavingRate;       // 절세율 (%)
+    }
+    
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TaxSummary {
+        private BigDecimal totalIsaTaxSaved;    // 총 ISA 절세액
+        private BigDecimal totalDepositTax;     // 총 예적금 세금
+        private BigDecimal totalTaxSaving;      // 총 절세액
+        private BigDecimal averageTaxSavingRate; // 평균 절세율
+        private int dataCount;                  // 데이터 개수 (분기 수)
+    }
+}

--- a/src/main/java/woojooin/planit/domain/tax/mapper/TaxComparisonMapper.java
+++ b/src/main/java/woojooin/planit/domain/tax/mapper/TaxComparisonMapper.java
@@ -1,0 +1,19 @@
+package woojooin.planit.domain.tax.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import woojooin.planit.domain.tax.dto.TaxComparisonRes;
+
+import java.util.List;
+
+@Mapper
+public interface TaxComparisonMapper {
+    
+    /**
+     * 최근 N분기 시계열 세금 비교 데이터 조회
+     */
+    List<TaxComparisonRes.QuarterlyTaxData> getTaxTrendByQuarters(
+        @Param("memberId") Long memberId,
+        @Param("quarters") Integer quarters
+    );
+}

--- a/src/main/java/woojooin/planit/domain/tax/service/TaxComparisonService.java
+++ b/src/main/java/woojooin/planit/domain/tax/service/TaxComparisonService.java
@@ -1,0 +1,78 @@
+package woojooin.planit.domain.tax.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import woojooin.planit.domain.tax.dto.TaxComparisonRes;
+import woojooin.planit.domain.tax.mapper.TaxComparisonMapper;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TaxComparisonService {
+    
+    private final TaxComparisonMapper taxComparisonMapper;
+    
+    /**
+     * 분기별 시계열 세금 비교 데이터 조회
+     */
+    public TaxComparisonRes getTaxTrend(Long memberId, Integer quarters) {
+        log.info("Getting tax trend for member: {}, quarters: {}", memberId, quarters);
+        
+        // 시계열 분기별 데이터 조회 (최근 N분기)
+        List<TaxComparisonRes.QuarterlyTaxData> quarterlyData = 
+            taxComparisonMapper.getTaxTrendByQuarters(memberId, quarters);
+        
+        // 요약 데이터 계산
+        TaxComparisonRes.TaxSummary summary = calculateSummary(quarterlyData);
+        
+        return TaxComparisonRes.builder()
+            .quarterlyData(quarterlyData)
+            .summary(summary)
+            .build();
+    }
+    
+    /**
+     * 요약 데이터 계산
+     */
+    private TaxComparisonRes.TaxSummary calculateSummary(List<TaxComparisonRes.QuarterlyTaxData> quarterlyData) {
+        if (quarterlyData.isEmpty()) {
+            return TaxComparisonRes.TaxSummary.builder()
+                .totalIsaTaxSaved(BigDecimal.ZERO)
+                .totalDepositTax(BigDecimal.ZERO)
+                .totalTaxSaving(BigDecimal.ZERO)
+                .averageTaxSavingRate(BigDecimal.ZERO)
+                .dataCount(0)
+                .build();
+        }
+        
+        BigDecimal totalIsaTaxSaved = quarterlyData.stream()
+            .map(data -> data.getIsaTaxSaved() != null ? data.getIsaTaxSaved() : BigDecimal.ZERO)
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+            
+        BigDecimal totalDepositTax = quarterlyData.stream()
+            .map(data -> data.getDepositTax() != null ? data.getDepositTax() : BigDecimal.ZERO)
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+            
+        BigDecimal totalTaxSaving = quarterlyData.stream()
+            .map(data -> data.getTotalTaxDifference() != null ? data.getTotalTaxDifference() : BigDecimal.ZERO)
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+            
+        BigDecimal averageTaxSavingRate = quarterlyData.stream()
+            .map(data -> data.getTaxSavingRate() != null ? data.getTaxSavingRate() : BigDecimal.ZERO)
+            .reduce(BigDecimal.ZERO, BigDecimal::add)
+            .divide(BigDecimal.valueOf(quarterlyData.size()), 2, RoundingMode.HALF_UP);
+        
+        return TaxComparisonRes.TaxSummary.builder()
+            .totalIsaTaxSaved(totalIsaTaxSaved)
+            .totalDepositTax(totalDepositTax)
+            .totalTaxSaving(totalTaxSaving)
+            .averageTaxSavingRate(averageTaxSavingRate)
+            .dataCount(quarterlyData.size())
+            .build();
+    }
+}

--- a/src/main/java/woojooin/planit/global/config/RootConfig.java
+++ b/src/main/java/woojooin/planit/global/config/RootConfig.java
@@ -37,7 +37,8 @@ import javax.sql.DataSource;
         "woojooin.planit.domain.goal.goalAccount.mapper",  // GoalAccount mapper 추가
         "woojooin.planit.domain.account.mapper",// Account mapper 추가
         "woojooin.planit.domain.openAi.mapper" ,// OpenAI mapper 추가
-        "woojooin.planit.domain.report.mapper" // report mapper 추가
+        "woojooin.planit.domain.report.mapper", // report mapper 추가
+        "woojooin.planit.domain.tax.mapper" // tax mapper 추가
 })
 @Slf4j
 @EnableTransactionManagement

--- a/src/main/java/woojooin/planit/global/config/ServletConfig.java
+++ b/src/main/java/woojooin/planit/global/config/ServletConfig.java
@@ -19,6 +19,7 @@ import org.springframework.web.servlet.view.JstlView;
 	"woojooin.planit.domain.goal.controller",
 	"woojooin.planit.domain.goal.deposit.controller",
 	"woojooin.planit.domain.product.controller",
+	"woojooin.planit.domain.tax.controller",  // tax 컨트롤러 추가
 	"woojooin.planit.global.exception"
 })
 public class ServletConfig  implements WebMvcConfigurer {


### PR DESCRIPTION
## 🔖 PR 유형
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
tax 비교 그래프를 위한 api

## 🔧 작업 내용
- ISA와 예적금의 세금 차이를 시계열 그래프로 시각화하기 위한 API 개발

## ✅ 체크리스트
- [ ] 테스트 완료(Postman, Swagger)

## 📝 기타 참고 사항
- 주의할 점, 추후 리팩토링 필요성 등

## 📎 관련 이슈
Close #이슈번호
