### PR TITLE
[fix] - 404 과거데이터 없음 오류

### DIFF
--- a/src/main/java/woojooin/planit/domain/goal/controller/GoalController.java
+++ b/src/main/java/woojooin/planit/domain/goal/controller/GoalController.java
@@ -93,7 +93,10 @@
 
     @GetMapping("/{goalId}/progress")
     @ApiOperation(value = "목표 일별 진행률 조회", notes = "특정 목표의 최근 6개월 일별 ISA/예적금 진행률 조회 (goal_id, isa_progress, deposit_progress, created_at)")
-    public Response<List<DailyGoalProgressResponse>> getGoalProgress(@PathVariable("goalId") Long goalId) {
+    public Response<List<DailyGoalProgressResponse>> getGoalProgress(
+        @PathVariable("goalId") Long goalId,
+        @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
         List<DailyGoalProgressResponse> progressList = goalService.getGoalProgress(goalId);
         return Response.ok(progressList);
     }

--- a/src/main/resources/mapper/goal/GoalMapper.xml
+++ b/src/main/resources/mapper/goal/GoalMapper.xml
@@ -147,14 +147,7 @@
             updated_at
         FROM daily_goal_progress
         WHERE goal_id = #{goalId}
-            AND DATE(created_at) IN (
-                CURDATE(),
-                DATE_SUB(CURDATE(), INTERVAL 1 MONTH),
-                DATE_SUB(CURDATE(), INTERVAL 2 MONTH),
-                DATE_SUB(CURDATE(), INTERVAL 3 MONTH),
-                DATE_SUB(CURDATE(), INTERVAL 4 MONTH),
-                DATE_SUB(CURDATE(), INTERVAL 5 MONTH)
-            )
+          AND created_at >= DATE_SUB(CURDATE(), INTERVAL 6 MONTH)
         ORDER BY created_at DESC
     </select>
 


### PR DESCRIPTION
과거 데이터가 충분하지 않아 정체 6개월 데이터 모두 넘기는 식으로 수정

## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
404 과거데이터 없음 오류

## 🔧 작업 내용
- 과거 월 별로 데이터 넘기던 걸 전체 6개월로 변경 

## ✅ 체크리스트
- [ ] 테스트 완료(Postman, Swagger)

## 📝 기타 참고 사항
- 주의할 점, 추후 리팩토링 필요성 등

## 📎 관련 이슈
Close #이슈번호
